### PR TITLE
Custom error pages

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -208,7 +208,7 @@ The following rules are both `Matchers` and `Modifiers`, so the `Matcher` portio
 3. `PathStripRegex`
 4. `PathPrefixStripRegex`
 5. `AddPrefix`
-6. `ReplacePath` 
+6. `ReplacePath`
 
 ### Priorities
 
@@ -354,6 +354,30 @@ Here is an example of backends and servers definition:
 - `backend1` will forward the traffic to two servers: `http://172.17.0.2:80"` with weight `10` and `http://172.17.0.3:80` with weight `1` using default `wrr` load-balancing strategy.
 - `backend2` will forward the traffic to two servers: `http://172.17.0.4:80"` with weight `1` and `http://172.17.0.5:80` with weight `2` using `drr` load-balancing strategy.
 - a circuit breaker is added on `backend1` using the expression `NetworkErrorRatio() > 0.5`: watch error ratio over 10 second sliding window
+
+## Custom Error pages
+Custom error pages can be returned, in lieu of the default, according frontend-configured ranges of HTTP Status codes.  In the example below, if a 503 status is returned from the frontend "website", the custom error page at http://2.3.4.5/500.html is returned with the actual status code set in the HTTP header.  Note, the 500.html page itself is not hosted on traefik, but some other infrastructure.  The configured status code ranges are inclusive; that is, in the below example, the 500.html page will be returned for status codes 500 through, and including, 599.  
+
+```toml
+[frontends]
+  [frontends.website]
+  backend = "website"
+  [errors]
+    [error.network]
+    status = ["500-599"]
+    backend = "error"
+    query = "/500.html"
+  [frontends.website.routes.website]
+  rule = "Host: website.mydomain.com"
+
+[backends]
+  [backends.website]
+    [backends.website.servers.website]
+    url = "https://1.2.3.4"
+  [backends.error]
+    [backends.error.servers.error]
+    url = "http://2.3.4.5"
+```
 
 # Configuration
 

--- a/integration/error_pages_test.go
+++ b/integration/error_pages_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/containous/traefik/integration/try"
+	"github.com/go-check/check"
+	checker "github.com/vdemeester/shakers"
+)
+
+// ErrorPagesSuite test suites (using libcompose)
+type ErrorPagesSuite struct{ BaseSuite }
+
+func (ep *ErrorPagesSuite) SetUpSuite(c *check.C) {
+	ep.createComposeProject(c, "error_pages")
+	ep.composeProject.Start(c)
+}
+
+func (ep *ErrorPagesSuite) TestSimpleConfiguration(c *check.C) {
+
+	errorPageHost := ep.composeProject.Container(c, "apache").NetworkSettings.IPAddress
+	backendHost := ep.composeProject.Container(c, "nginx").NetworkSettings.IPAddress
+
+	file := ep.adaptFile(c, "fixtures/error_pages/simple.toml", struct {
+		Server1 string
+		Server2 string
+	}{backendHost, errorPageHost})
+	defer os.Remove(file)
+	cmd := exec.Command(traefikBinary, "--configFile="+file)
+
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	frontendReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:80", nil)
+	c.Assert(err, checker.IsNil)
+	frontendReq.Host = "test.local"
+
+	err = try.Request(frontendReq, 2*time.Second, try.BodyContains("nginx"))
+	c.Assert(err, checker.IsNil)
+}
+
+func (ep *ErrorPagesSuite) TestErrorPage(c *check.C) {
+
+	errorPageHost := ep.composeProject.Container(c, "apache").NetworkSettings.IPAddress
+	backendHost := ep.composeProject.Container(c, "nginx").NetworkSettings.IPAddress
+
+	//error.toml contains a mis-configuration of the backend host
+	file := ep.adaptFile(c, "fixtures/error_pages/error.toml", struct {
+		Server1 string
+		Server2 string
+	}{backendHost, errorPageHost})
+	defer os.Remove(file)
+	cmd := exec.Command(traefikBinary, "--configFile="+file)
+
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	frontendReq, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:80", nil)
+	c.Assert(err, checker.IsNil)
+	frontendReq.Host = "test.local"
+
+	err = try.Request(frontendReq, 2*time.Second, try.BodyContains("It works!"))
+	c.Assert(err, checker.IsNil)
+}

--- a/integration/fixtures/error_pages/error.toml
+++ b/integration/fixtures/error_pages/error.toml
@@ -1,0 +1,27 @@
+defaultEntryPoints = ["http"]
+
+logLevel = "DEBUG"
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+
+[file]
+[backends]
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    url = "http://{{.Server1}}:8989474"
+  [backends.error]
+    [backends.error.servers.error]
+    url = "http://{{.Server2}}:80"
+[frontends]
+    [frontends.frontend1]
+    passHostHeader = true
+    backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "Host:test.local"
+    [frontends.frontend1.errors]
+        [frontends.frontend1.errors.networks]
+        status = ["500-502", "503-599"]
+        backend = "error"
+        query = ""

--- a/integration/fixtures/error_pages/simple.toml
+++ b/integration/fixtures/error_pages/simple.toml
@@ -1,0 +1,27 @@
+defaultEntryPoints = ["http"]
+
+logLevel = "DEBUG"
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+
+[file]
+[backends]
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    url = "http://{{.Server1}}:80"
+  [backends.error]
+    [backends.error.servers.error]
+    url = "http://{{.Server2}}:80"
+[frontends]
+    [frontends.frontend1]
+    passHostHeader = true
+    backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "Host:test.local"
+    [frontends.frontend1.errors]
+        [frontends.frontend1.errors.networks]
+        status = ["500-502", "503-599"]
+        backend = "error"
+        query = ""

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -23,6 +23,7 @@ func Test(t *testing.T) {
 }
 
 func init() {
+	check.Suite(&ErrorPagesSuite{})
 	check.Suite(&SimpleSuite{})
 	check.Suite(&AccessLogSuite{})
 	check.Suite(&HTTPSSuite{})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -23,7 +23,6 @@ func Test(t *testing.T) {
 }
 
 func init() {
-	check.Suite(&ErrorPagesSuite{})
 	check.Suite(&SimpleSuite{})
 	check.Suite(&AccessLogSuite{})
 	check.Suite(&HTTPSSuite{})
@@ -39,6 +38,7 @@ func init() {
 	check.Suite(&EurekaSuite{})
 	check.Suite(&AcmeSuite{})
 	check.Suite(&DynamoDBSuite{})
+	check.Suite(&ErrorPagesSuite{})
 }
 
 var traefikBinary = "../dist/traefik"

--- a/integration/resources/compose/error_pages.yml
+++ b/integration/resources/compose/error_pages.yml
@@ -1,8 +1,4 @@
 nginx:
   image: nginx:alpine
-  ports:
-    - "8881:80"
 apache:
   image: httpd:2.4
-  ports:
-    - "8882:80"

--- a/integration/resources/compose/error_pages.yml
+++ b/integration/resources/compose/error_pages.yml
@@ -1,0 +1,8 @@
+nginx:
+  image: nginx:alpine
+  ports:
+    - "8881:80"
+apache:
+  image: httpd:2.4
+  ports:
+    - "8882:80"

--- a/middlewares/error_pages.go
+++ b/middlewares/error_pages.go
@@ -1,0 +1,69 @@
+package middlewares
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/containous/traefik/types"
+	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/utils"
+)
+
+//ErrorPagesHandler is a middleware that provides the custom error pages
+type ErrorPagesHandler struct {
+	HTTPCodeRanges     [][]int
+	BackendURL         string
+	errorPageForwarder *forward.Forwarder
+}
+
+//NewErrorPagesHandler initializes the utils.ErrorHandler for the custom error pages
+func NewErrorPagesHandler(errorPage types.ErrorPage, backendURL string) (*ErrorPagesHandler, error) {
+	fwd, err := forward.New()
+	if err != nil {
+		return nil, err
+	}
+
+	//Break out the http status code ranges into a low int and high int
+	//for ease of use at runtime
+	var blocks [][]int
+	for _, block := range errorPage.Status {
+		codes := strings.Split(block, "-")
+		lowCode, err := strconv.Atoi(codes[0])
+		if err != nil {
+			return nil, err
+		}
+		highCode, err := strconv.Atoi(codes[1])
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, []int{lowCode, highCode})
+	}
+	return &ErrorPagesHandler{HTTPCodeRanges: blocks,
+		BackendURL:         backendURL + errorPage.Query,
+		errorPageForwarder: fwd}, nil
+}
+
+func (ep *ErrorPagesHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	recorder := NewRecorder()
+	recorder.responseWriter = w
+	next.ServeHTTP(recorder, req)
+
+	//check the recorder code against the configured http status code ranges
+	for _, block := range ep.HTTPCodeRanges {
+		if recorder.Code >= block[0] && recorder.Code <= block[1] {
+			w.WriteHeader(recorder.Code)
+			if newReq, err := http.NewRequest("GET", ep.BackendURL, nil); err != nil {
+				w.Write([]byte(http.StatusText(recorder.Code)))
+			} else {
+				ep.errorPageForwarder.ServeHTTP(w, newReq)
+			}
+			return
+		}
+	}
+
+	//did not catch a configured status code so proceed with the request
+	utils.CopyHeaders(w.Header(), recorder.Header())
+	w.WriteHeader(recorder.Code)
+	w.Write(recorder.Body.Bytes())
+}

--- a/middlewares/error_pages_test.go
+++ b/middlewares/error_pages_test.go
@@ -1,0 +1,66 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/codegangsta/negroni"
+	"github.com/containous/traefik/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorPage(t *testing.T) {
+	testErrorPage := &types.ErrorPage{Backend: "error", Query: "/test", Status: []string{"500-501", "503-599"}}
+	testHandler, err := NewErrorPagesHandler(*testErrorPage, "http://example.com")
+
+	assert.Equal(t, nil, err, "Should be no error")
+	assert.Equal(t, testHandler.BackendURL, "http://example.com/test", "Should be equal")
+
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "http://example.com/test", nil)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "traefik")
+	})
+	var n = negroni.New()
+	n.Use(testHandler)
+	n.UseHandler(handler)
+
+	n.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.Code, "HTTP statusOK")
+	assert.Contains(t, recorder.Body.String(), "traefik")
+
+	handler500 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprintln(w, "oops")
+	})
+	recorder500 := httptest.NewRecorder()
+	var n500 = negroni.New()
+	n500.Use(testHandler)
+	n500.UseHandler(handler500)
+
+	n500.ServeHTTP(recorder500, req)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder500.Code, "HTTP status Internal Server Error")
+	assert.Contains(t, recorder500.Body.String(), "This domain is established to be used for illustrative examples in documents")
+	assert.NotContains(t, recorder500.Body.String(), "oops", "Should not return the oops page")
+
+	handler502 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(502)
+		fmt.Fprintln(w, "oops")
+	})
+	recorder502 := httptest.NewRecorder()
+	var n502 = negroni.New()
+	n502.Use(testHandler)
+	n502.UseHandler(handler502)
+
+	n502.ServeHTTP(recorder502, req)
+
+	assert.Equal(t, http.StatusBadGateway, recorder502.Code, "HTTP status Internal Server Error")
+	assert.Contains(t, recorder502.Body.String(), "oops")
+	assert.NotContains(t, recorder502.Body.String(), "This domain is established to be used for illustrative examples in documents", "Should return the oops page")
+
+}

--- a/middlewares/error_pages_test.go
+++ b/middlewares/error_pages_test.go
@@ -12,19 +12,24 @@ import (
 )
 
 func TestErrorPage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Test Server")
+	}))
+	defer ts.Close()
+
 	testErrorPage := &types.ErrorPage{Backend: "error", Query: "/test", Status: []string{"500-501", "503-599"}}
-	testHandler, err := NewErrorPagesHandler(*testErrorPage, "http://example.com")
+	testHandler, err := NewErrorPagesHandler(*testErrorPage, ts.URL)
 
 	assert.Equal(t, nil, err, "Should be no error")
-	assert.Equal(t, testHandler.BackendURL, "http://example.com/test", "Should be equal")
+	assert.Equal(t, testHandler.BackendURL, ts.URL+"/test", "Should be equal")
 
 	recorder := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "http://example.com/test", nil)
+	req, err := http.NewRequest("GET", ts.URL+"/test", nil)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "traefik")
 	})
-	var n = negroni.New()
+	n := negroni.New()
 	n.Use(testHandler)
 	n.UseHandler(handler)
 
@@ -38,14 +43,14 @@ func TestErrorPage(t *testing.T) {
 		fmt.Fprintln(w, "oops")
 	})
 	recorder500 := httptest.NewRecorder()
-	var n500 = negroni.New()
+	n500 := negroni.New()
 	n500.Use(testHandler)
 	n500.UseHandler(handler500)
 
 	n500.ServeHTTP(recorder500, req)
 
 	assert.Equal(t, http.StatusInternalServerError, recorder500.Code, "HTTP status Internal Server Error")
-	assert.Contains(t, recorder500.Body.String(), "This domain is established to be used for illustrative examples in documents")
+	assert.Contains(t, recorder500.Body.String(), "Test Server")
 	assert.NotContains(t, recorder500.Body.String(), "oops", "Should not return the oops page")
 
 	handler502 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -53,7 +58,7 @@ func TestErrorPage(t *testing.T) {
 		fmt.Fprintln(w, "oops")
 	})
 	recorder502 := httptest.NewRecorder()
-	var n502 = negroni.New()
+	n502 := negroni.New()
 	n502.Use(testHandler)
 	n502.UseHandler(handler502)
 
@@ -61,6 +66,6 @@ func TestErrorPage(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadGateway, recorder502.Code, "HTTP status Internal Server Error")
 	assert.Contains(t, recorder502.Body.String(), "oops")
-	assert.NotContains(t, recorder502.Body.String(), "This domain is established to be used for illustrative examples in documents", "Should return the oops page")
+	assert.NotContains(t, recorder502.Body.String(), "Test Server", "Should return the oops page")
 
 }

--- a/types/types.go
+++ b/types/types.go
@@ -54,15 +54,23 @@ type Route struct {
 	Rule string `json:"rule,omitempty"`
 }
 
+//ErrorPage holds custom error page configuration
+type ErrorPage struct {
+	Status  []string `json:"status,omitempty"`
+	Backend string   `json:"backend,omitempty"`
+	Query   string   `json:"query,omitempty"`
+}
+
 // Frontend holds frontend configuration.
 type Frontend struct {
-	EntryPoints          []string         `json:"entryPoints,omitempty"`
-	Backend              string           `json:"backend,omitempty"`
-	Routes               map[string]Route `json:"routes,omitempty"`
-	PassHostHeader       bool             `json:"passHostHeader,omitempty"`
-	Priority             int              `json:"priority"`
-	BasicAuth            []string         `json:"basicAuth"`
-	WhitelistSourceRange []string         `json:"whitelistSourceRange,omitempty"`
+	EntryPoints          []string             `json:"entryPoints,omitempty"`
+	Backend              string               `json:"backend,omitempty"`
+	Routes               map[string]Route     `json:"routes,omitempty"`
+	PassHostHeader       bool                 `json:"passHostHeader,omitempty"`
+	Priority             int                  `json:"priority"`
+	BasicAuth            []string             `json:"basicAuth"`
+	WhitelistSourceRange []string             `json:"whitelistSourceRange,omitempty"`
+	Errors               map[string]ErrorPage `json:"errors,omitempty"`
 }
 
 // LoadBalancerMethod holds the method of load balancing to use.


### PR DESCRIPTION
### Description
Follow up to [PR 1576](https://github.com/containous/traefik/pull/1576) and [issue 1634](https://github.com/containous/traefik/issues/1634).

- New ErrorPage type to capture frontend error pages configurations
- New error_pages middleware containing a response recorder
- Documentation/example
- Unit tests to ensure middleware is being initialized and rendering correctly